### PR TITLE
Host uses Trees for topics, add initial `request()` implementation for UDP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ quic = ["quinn", "rustls", "rustls-pemfile", "rcgen", "futures-util"]
 
 [dependencies]
 # de/serialization and message sending
-serde = {version = "=1.0.171", default-features = false, features = ["derive"]}
+serde = {version = "1", default-features = false, features = ["derive"]}
 postcard = {version = "1", features = ["alloc"]}
 chrono = {version = "0.4", features = ["serde"]}
 # key value store, networking, and async

--- a/Deny.toml
+++ b/Deny.toml
@@ -1,5 +1,0 @@
-[bans]
-deny = [
-    # See https://github.com/serde-rs/serde/issues/2538
-    { name = "serde_derive", version = ">1.0.171" },
-]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ meadow currently supports the following messaging patterns:
 | Protocol | Publish   | Request    | Subscribe | Encryption |
 |----------|-----------|------------|-----------|------------|
 | TCP      | **X**     | **X**      | **X**     |            |
-| UDP      | **X**     |            |           |            |
+| UDP      | **X**     | **X**      |           |            |
 | QUIC     | **X**     | **X**      | **X**     | **X**      |
 
 ## Key Dependencies

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ Under the hood, `meadow` relies on:
 
 ## Benchmarks
 Preliminary benchmark data is showing round-trip message times (publish-request-reply) on `locahost` using the `--release`
-compilation profile, on the README's `Coordinate` data (strongly-typed, 8 bytes) to be ~100 microseconds.
+compilation profile, on the README's `Coordinate` data (strongly-typed, 8 bytes) to be <50 microseconds.
 
-Additional benchmarking information can be found using `cargo run --release --example benchmark`. 
+Statistical benchmarks on different data profiles can be run via [`criterion`](https://github.com/bheisler/criterion.rs) via `cargo bench`.
 
 ## Stability
 As mentioned above, this library should be considered *experimental*. While the goal is eventually to make this available at a level of maturity, stability, and reliability of other middlewares, `meadow` is not there yet. This library is being used as a dependency for robotics research, with interprocess communication focused on dozens of nodes on `localhost` or a few over a WLAN connection. While `meadow` can work for other use-cases, it has not been extensively tested in those areas. If you are using this library in other areas and come across issues or unexpected behavior, well-formatted bug reports or pull requests addressing those problems are welcomed. 

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ fn main() -> Result<(), meadow::Error> {
     host.start()?;
     // Other tasks can operate while the host is running in the background
 
-    // Build a Node
+    // Build a Node. Nodes can run over TCP, UDP, or QUIC
     let addr = "127.0.0.1:25000".parse::<std::net::SocketAddr>().unwrap();
-    let node: Node<Tcp, Idle, Coordinate> = NodeConfig::new("position")
-        .with_config(node::NetworkConfig::<Tcp>::default().set_host_addr(addr))
+    let node: Node<Udp, Idle, Coordinate> = NodeConfig::new("position")
+        .with_config(node::NetworkConfig::<Udp>::default().set_host_addr(addr))
         .build()?;
-    // meadow Nodes use strict typestates; without using the activate() method first,
+    // Nodes use strict typestates; without using the activate() method first,
     // the compiler won't let allow publish() or request() methods on an Idle Node
-    let node: Node<Tcp, Active, Coordinate> = node.activate()?;
+    let node: Node<Udp, Active, Coordinate> = node.activate()?;
 
     // Since Nodes are statically-typed, the following lines would fail at
     // compile-time due to type errors
@@ -57,7 +57,6 @@ fn main() -> Result<(), meadow::Error> {
         println!("request: {:?}, subscription: {:?}", result, subscription);
     }
 
-    host.stop()?;
     Ok(())
 }
 ```

--- a/examples/host_and_single_node.rs
+++ b/examples/host_and_single_node.rs
@@ -16,7 +16,20 @@ struct Pose {
 fn main() -> Result<(), meadow::Error> {
     logging();
 
-    let mut host: Host = HostConfig::default().build()?;
+    // Configure the Host a
+    let mut host = {
+        let date = chrono::Utc::now();
+        let stamp = format!(
+            "{}_{}_UTC",
+            date.date_naive().to_string(),
+            date.time().format("%H:%M:%S").to_string()
+        );
+        let sled_cfg = SledConfig::default()
+            .path(format!("./logs/{}", stamp))
+            // If we wanted to keep the logs, we'd make this `false`
+            .temporary(true);
+        HostConfig::default().with_sled_config(sled_cfg).build()?
+    };
     host.start()?;
     println!("Host should be running in the background");
 
@@ -53,6 +66,15 @@ fn main() -> Result<(), meadow::Error> {
         "The size of an a meadow Host before shutdown is: {}",
         std::mem::size_of_val(&host)
     );
+    let topics = host.topics();
+    for topic in &topics {
+        if let Some(ref db) = host.store {
+            let db = db.clone();
+            let tree = db.open_tree(topic.as_bytes()).unwrap();
+            println!("Topic {} has {} stored values", topic, tree.len());
+        }
+    }
+
     host.stop()?;
     Ok(())
 }

--- a/examples/host_and_single_node.rs
+++ b/examples/host_and_single_node.rs
@@ -16,7 +16,7 @@ struct Pose {
 fn main() -> Result<(), meadow::Error> {
     logging();
 
-    // Configure the Host a
+    // Configure the Host with logging
     let mut host = {
         let date = chrono::Utc::now();
         let stamp = format!(

--- a/examples/host_and_single_node.rs
+++ b/examples/host_and_single_node.rs
@@ -75,7 +75,6 @@ fn main() -> Result<(), meadow::Error> {
         }
     }
 
-    host.stop()?;
     Ok(())
 }
 

--- a/examples/host_and_single_node.rs
+++ b/examples/host_and_single_node.rs
@@ -21,8 +21,8 @@ fn main() -> Result<(), meadow::Error> {
         let date = chrono::Utc::now();
         let stamp = format!(
             "{}_{}_UTC",
-            date.date_naive().to_string(),
-            date.time().format("%H:%M:%S").to_string()
+            date.date_naive(),
+            date.time().format("%H:%M:%S")
         );
         let sled_cfg = SledConfig::default()
             .path(format!("./logs/{}", stamp))

--- a/examples/stress.rs
+++ b/examples/stress.rs
@@ -1,0 +1,87 @@
+use meadow::*;
+use rand::Rng;
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn main() -> Result<(), meadow::Error> {
+    let mut host = HostConfig::default()
+        .with_sled_config(
+            SledConfig::default()
+                .temporary(false)
+                .path("./logs/stress.sled"),
+        )
+        .build()?;
+    host.start()?;
+
+    let duration = Duration::from_secs(10);
+    let n = 10;
+
+    let tcp = thread::spawn(move || {
+        run_tcp(n, duration).unwrap();
+    });
+
+    let udp = thread::spawn(move || {
+        run_udp(n, duration).unwrap();
+    });
+
+    thread::sleep(duration);
+
+    if let Err(e) = tcp.join() {
+        println!("TCP error: {:?}", e);
+    }
+
+    if let Err(e) = udp.join() {
+        println!("UDP error: {:?}", e);
+    }
+
+    let topics = host.topics();
+    for topic in &topics {
+        if let Some(ref db) = host.store {
+            let db = db.clone();
+            let tree = db.open_tree(topic.as_bytes()).unwrap();
+            println!("Topic {} has {} stored values", topic, tree.len());
+        }
+    }
+
+    Ok(())
+}
+
+fn run_tcp(n: usize, duration: Duration) -> Result<(), meadow::Error> {
+    let mut nodes = Vec::with_capacity(n);
+    for i in 0..n {
+        let topic = format!("tcp_{}", i);
+        let node = NodeConfig::<Tcp, f32>::new(topic).build()?;
+        let node = node.activate()?;
+        nodes.push(node);
+    }
+
+    let start = Instant::now();
+    let mut rng = rand::thread_rng();
+    while start.elapsed() < duration {
+        for node in &mut nodes {
+            node.publish(rng.gen())?;
+            node.request()?;
+        }
+    }
+    Ok(())
+}
+
+fn run_udp(n: usize, duration: Duration) -> Result<(), meadow::Error> {
+    let mut nodes = Vec::with_capacity(n);
+    for i in 0..n {
+        let topic = format!("udp_{}", i);
+        let node = NodeConfig::<Udp, f32>::new(topic).build()?;
+        let node = node.activate()?;
+        nodes.push(node);
+    }
+
+    let start = Instant::now();
+    let mut rng = rand::thread_rng();
+    while start.elapsed() < duration {
+        for node in &mut nodes {
+            node.publish(rng.gen())?;
+            node.request()?;
+        }
+    }
+    Ok(())
+}

--- a/examples/udp.rs
+++ b/examples/udp.rs
@@ -4,48 +4,25 @@ use std::time::Duration;
 
 fn main() -> Result<(), meadow::Error> {
     let mut host = HostConfig::default()
-        // .with_sled_config(SledConfig::default().path("store").temporary(true))
-        // .with_tcp_config(None)
-        .with_udp_config(Some(host::TcpConfig::default("lo")))
+        .with_udp_config(Some(host::UdpConfig::default("lo")))
+        .with_tcp_config(None)
         .build()?;
     host.start()?;
     println!("Started host");
 
-    let tx_thread = thread::spawn(|| {
-        let tx = NodeConfig::<Udp, f32>::new("num")
-            .with_config(node::NetworkConfig::<Udp>::default())
-            .build()
-            .unwrap()
-            .activate()
-            .unwrap();
-        dbg!(&tx);
-        println!("Built first node");
-        for i in 0..10 {
-            let x = i as f32;
-
-            match tx.publish(x) {
-                Ok(_) => (),
-                Err(e) => {
-                    dbg!(e);
-                }
-            };
-            println!("published {} over udp", i);
-            thread::sleep(Duration::from_millis(100));
-        }
-        std::process::exit(0);
-    });
-
-    let rx = NodeConfig::<Tcp, f32>::new("num")
+    let node = NodeConfig::<Udp, f32>::new("num")
         .build()
         .unwrap()
         .activate()?;
 
-    for _i in 0..20 {
+    for i in 0..10 {
+        node.publish(i as f32)?;
         thread::sleep(Duration::from_millis(50));
-        let result = rx.request().unwrap();
+        let result = node.request()?;
         dbg!(result);
     }
 
-    tx_thread.join().unwrap();
+    host.stop()?;
+
     Ok(())
 }

--- a/src/bin/certs.rs
+++ b/src/bin/certs.rs
@@ -4,6 +4,6 @@ use meadow::host::quic::generate_certs;
 fn main() {
     #[cfg(feature = "quic")]
     generate_certs().unwrap();
-    #[cfg(not(features = "quic"))]
+    #[cfg(not(feature = "quic"))]
     panic!("Must enable the \"quic\" feature to run");
 }

--- a/src/error/host_operation.rs
+++ b/src/error/host_operation.rs
@@ -3,7 +3,6 @@ use serde::*;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum HostOperation {
-    Success,
     SetFailure,
     GetFailure,
     ConnectionError,
@@ -13,7 +12,6 @@ impl std::error::Error for HostOperation {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use HostOperation::*;
         match *self {
-            Success => None,
             SetFailure => None,
             GetFailure => None,
             ConnectionError => None,
@@ -25,7 +23,6 @@ impl Display for HostOperation {
     fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
         use HostOperation::*;
         match *self {
-            Success => write!(f, "Success Host-side operation"),
             SetFailure => write!(f, "Unsuccessful Host-side SET operation"),
             GetFailure => write!(f, "Unsuccessful Host-side SET operation"),
             ConnectionError => write!(f, "Unsuccessful Host connection"),

--- a/src/host/config.rs
+++ b/src/host/config.rs
@@ -31,7 +31,7 @@ impl Default for HostConfig {
             date.time().format("%H:%M:%S").to_string()
         );
         let sled_cfg = sled::Config::default()
-            .path(format!("./logs/{}", stamp))
+            .path(format!("./logs/{}.sled", stamp))
             .temporary(true);
 
         HostConfig {

--- a/src/host/config.rs
+++ b/src/host/config.rs
@@ -30,7 +30,9 @@ impl Default for HostConfig {
             date.date_naive().to_string(),
             date.time().format("%H:%M:%S").to_string()
         );
-        let sled_cfg = sled::Config::default().path(stamp).temporary(true);
+        let sled_cfg = sled::Config::default()
+            .path(format!("./logs/{}", stamp))
+            .temporary(true);
 
         HostConfig {
             sled_cfg,

--- a/src/host/config.rs
+++ b/src/host/config.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use chrono::Utc;
 
 // Tokio for async
 use tokio::sync::Mutex; // as TokioMutex;
@@ -23,7 +24,13 @@ impl Default for HostConfig {
     /// Create a new `HostConfig` with all default options
     fn default() -> HostConfig {
         // Default sled database configuration
-        let sled_cfg = sled::Config::default().path("store").temporary(true);
+        let date = Utc::now();
+        let stamp = format!(
+            "{}_{}_UTC",
+            date.date_naive().to_string(),
+            date.time().format("%H:%M:%S").to_string()
+        );
+        let sled_cfg = sled::Config::default().path(stamp).temporary(true);
 
         HostConfig {
             sled_cfg,

--- a/src/host/config.rs
+++ b/src/host/config.rs
@@ -27,8 +27,8 @@ impl Default for HostConfig {
         let date = Utc::now();
         let stamp = format!(
             "{}_{}_UTC",
-            date.date_naive().to_string(),
-            date.time().format("%H:%M:%S").to_string()
+            date.date_naive(),
+            date.time().format("%H:%M:%S")
         );
         let sled_cfg = sled::Config::default()
             .path(format!("./logs/{}.sled", stamp))

--- a/src/host/host.rs
+++ b/src/host/host.rs
@@ -261,6 +261,21 @@ impl Host {
         }
     }
 
+    pub fn topics(&self) -> Vec<String> {
+        if let Some(db) = self.store.clone() {
+            let names = db.tree_names();
+            let mut strings = Vec::new();
+            for name in names {
+                let name = std::str::from_utf8(&name[..]).unwrap();
+                strings.push(name.to_string());
+            }
+
+            strings
+        } else {
+            Vec::new()
+        }
+    }
+
     /// Print information about all Host connections
     #[no_mangle]
     pub fn print_connections(&mut self) -> Result<(), crate::Error> {

--- a/src/host/tcp.rs
+++ b/src/host/tcp.rs
@@ -119,8 +119,8 @@ pub async fn process_tcp(
                                         *count += 1;
                                         break;
                                     }
-                                    Err(e) => {
-                                        if e.kind() == std::io::ErrorKind::WouldBlock {}
+                                    Err(_e) => {
+                                        // if e.kind() == std::io::ErrorKind::WouldBlock {}
                                         continue;
                                     }
                                 }
@@ -148,8 +148,8 @@ pub async fn process_tcp(
                                 *count += 1;
                                 break;
                             }
-                            Err(e) => {
-                                if e.kind() == std::io::ErrorKind::WouldBlock {}
+                            Err(_e) => {
+                                // if e.kind() == std::io::ErrorKind::WouldBlock {}
                                 continue;
                             }
                         }

--- a/src/host/udp.rs
+++ b/src/host/udp.rs
@@ -42,14 +42,18 @@ pub async fn process_udp(
                 match msg.msg_type {
                     MsgType::SET => {
                         // println!("received {} bytes, to be assigned to: {}", n, &msg.name);
-                        let _db_result = match db.insert(msg.topic.as_bytes(), bytes) {
-                            Ok(_prev_msg) => {
-                                let mut count = count.lock().await; //.unwrap();
-                                *count += 1;
-                                "SUCCESS".to_string()
-                            }
-                            Err(e) => e.to_string(),
-                        };
+                        let tree = db
+                            .open_tree(msg.topic.as_bytes())
+                            .expect("Error opening tree");
+                        let _db_result =
+                            match tree.insert(msg.timestamp.to_string().as_bytes(), bytes) {
+                                Ok(_prev_msg) => {
+                                    let mut count = count.lock().await; //.unwrap();
+                                    *count += 1;
+                                    "SUCCESS".to_string()
+                                }
+                                Err(e) => e.to_string(),
+                            };
                     }
                     MsgType::GET => loop {
                         println!("Hey, we're not doing UDP responses rn");

--- a/src/host/udp.rs
+++ b/src/host/udp.rs
@@ -72,7 +72,7 @@ pub async fn process_udp(
                         println!("return_addr: {:?}", return_addr);
                         if let Ok(()) = socket.writable().await {
                             if let Err(e) = socket.try_send_to(&return_bytes, return_addr) {
-                                error!("Error sending data back on UDP/GET")
+                                error!("Error sending data back on UDP/GET: {}", e)
                             };
                         };
                     }

--- a/src/host/udp.rs
+++ b/src/host/udp.rs
@@ -69,7 +69,7 @@ pub async fn process_udp(
                                 e.as_bytes().into()
                             }
                         };
-                        println!("return_addr: {:?}", return_addr);
+
                         if let Ok(()) = socket.writable().await {
                             if let Err(e) = socket.try_send_to(&return_bytes, return_addr) {
                                 error!("Error sending data back on UDP/GET: {}", e)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,5 +46,6 @@ pub use crate::host::{Host, HostConfig};
 pub use crate::msg::{GenericMsg, Message, Msg, MsgType};
 pub use crate::networks::get_ip;
 pub use crate::node::{
-    await_response, send_msg, Active, Idle, NetworkConfig, Node, NodeConfig, Subscription, Tcp, Udp,
+    tcp::await_response, tcp::send_msg, Active, Idle, NetworkConfig, Node, NodeConfig,
+    Subscription, Tcp, Udp,
 };

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -2,8 +2,8 @@ mod config;
 mod network_config;
 #[cfg(feature = "quic")]
 mod quic;
-mod tcp;
-mod udp;
+pub mod tcp;
+pub mod udp;
 
 pub use crate::node::config::*;
 pub use crate::node::network_config::NetworkConfig;

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -13,7 +13,6 @@ pub use crate::node::network_config::{Tcp, Udp};
 #[cfg(feature = "quic")]
 pub use crate::node::quic::*;
 pub use crate::node::tcp::*;
-pub use crate::node::udp::*;
 
 extern crate alloc;
 

--- a/src/node/network_config.rs
+++ b/src/node/network_config.rs
@@ -26,6 +26,7 @@ where
     pub max_buffer_size: usize,
     pub cert_path: Option<PathBuf>,
     pub key_path: Option<PathBuf>,
+    pub send_tries: usize,
 }
 
 impl Default for NetworkConfig<Tcp> {
@@ -36,6 +37,7 @@ impl Default for NetworkConfig<Tcp> {
             max_buffer_size: 1024,
             cert_path: None,
             key_path: None,
+            send_tries: 10,
         }
     }
 }
@@ -62,6 +64,7 @@ impl Default for NetworkConfig<Udp> {
             max_buffer_size: 2048,
             cert_path: None,
             key_path: None,
+            send_tries: 10,
         }
     }
 }
@@ -86,6 +89,7 @@ impl Default for NetworkConfig<Quic> {
             __interface: PhantomData::<Quic>,
             host_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 25_000),
             max_buffer_size: 4096,
+            send_tries: 10,
             cert_path: Some(Path::new("target").join("cert.pem")),
             key_path: Some(Path::new("target").join("priv_key.pem")),
         }

--- a/src/node/quic/active.rs
+++ b/src/node/quic/active.rs
@@ -90,7 +90,7 @@ impl<T: Message + 'static> Node<Quic, Active, T> {
                                 }
                             }
                             _ => {
-                                // if e.kind() == std::io::ErrorKind::WouldBlock {}
+                                // // if e.kind() == std::io::ErrorKind::WouldBlock {}
                                 Err(Error::Quic(RecvRead))
                             }
                         }

--- a/src/node/quic/idle.rs
+++ b/src/node/quic/idle.rs
@@ -158,7 +158,7 @@ impl<T: Message + 'static> Node<Quic, Idle, T> {
                                     }
                                 }
                                 _ => {
-                                    // if e.kind() == std::io::ErrorKind::WouldBlock {}
+                                    // // if e.kind() == std::io::ErrorKind::WouldBlock {}
                                     continue;
                                 }
                             }

--- a/src/node/tcp/active.rs
+++ b/src/node/tcp/active.rs
@@ -43,7 +43,9 @@ impl<T: Message + 'static> Node<Tcp, Active, T> {
         };
 
         self.runtime.block_on(async {
-            send_msg(&mut stream, packet_as_bytes).await.unwrap();
+            crate::node::tcp::send_msg(&mut stream, packet_as_bytes)
+                .await
+                .unwrap();
 
             // Wait for the publish acknowledgement
             let mut buf = vec![0u8; 1024];
@@ -101,8 +103,15 @@ impl<T: Message + 'static> Node<Tcp, Active, T> {
         };
 
         self.runtime.block_on(async {
-            send_msg(&mut stream, packet_as_bytes).await.unwrap();
-            match await_response::<T>(&mut stream, self.cfg.network_cfg.max_buffer_size).await {
+            crate::node::tcp::send_msg(&mut stream, packet_as_bytes)
+                .await
+                .unwrap();
+            match crate::node::tcp::await_response::<T>(
+                &mut stream,
+                self.cfg.network_cfg.max_buffer_size,
+            )
+            .await
+            {
                 Ok(msg) => Ok(msg),
                 Err(_e) => Err(Error::Deserialization),
             }

--- a/src/node/tcp/active.rs
+++ b/src/node/tcp/active.rs
@@ -54,13 +54,13 @@ impl<T: Message + 'static> Node<Tcp, Active, T> {
                     Ok(n) => {
                         let bytes = &buf[..n];
                         // TO_DO: This error handling is not great
-                        match from_bytes::<Error>(bytes) {
+                        match from_bytes::<Result<(), Error>>(bytes) {
                             Err(e) => {
                                 error!("{:?}", e);
                             }
-                            Ok(e) => match e {
-                                Error::HostOperation(error::HostOperation::Success) => (),
-                                _ => {
+                            Ok(result) => match result {
+                                Ok(()) => (),
+                                Err(e) => {
                                     error!("{:?}", e);
                                 }
                             },

--- a/src/node/tcp/idle.rs
+++ b/src/node/tcp/idle.rs
@@ -139,8 +139,8 @@ impl<T: Message + 'static> Node<Tcp, Idle, T> {
 
             loop {
                 let packet_as_bytes: Vec<u8> = to_allocvec(&packet).unwrap();
-                send_msg(&mut &stream, packet_as_bytes).await.unwrap();
-                let msg = match await_response::<T>(&mut &stream, max_buffer_size).await {
+                send_msg(&stream, packet_as_bytes).await.unwrap();
+                let msg = match await_response::<T>(&stream, max_buffer_size).await {
                     Ok(msg) => msg,
                     Err(e) => {
                         error!("Subscription Error: {}", e);

--- a/src/node/tcp/mod.rs
+++ b/src/node/tcp/mod.rs
@@ -1,4 +1,3 @@
-// mod network_config;
 mod active;
 mod idle;
 mod subscription;

--- a/src/node/tcp/mod.rs
+++ b/src/node/tcp/mod.rs
@@ -88,7 +88,7 @@ pub async fn handshake(stream: TcpStream, topic: String) -> Result<TcpStream, Er
 }
 
 /// Send a `GenericMsg` of `MsgType` from the Node to the Host
-pub async fn send_msg(stream: &mut &TcpStream, packet_as_bytes: Vec<u8>) -> Result<(), Error> {
+pub async fn send_msg(stream: &TcpStream, packet_as_bytes: Vec<u8>) -> Result<(), Error> {
     match stream.writable().await {
         Ok(_) => (),
         Err(_e) => return Err(Error::AccessStream),
@@ -102,8 +102,8 @@ pub async fn send_msg(stream: &mut &TcpStream, packet_as_bytes: Vec<u8>) -> Resu
                 // debug!("Node successfully wrote {}-byte request to host",n);
                 break;
             }
-            Err(e) => {
-                if e.kind() == std::io::ErrorKind::WouldBlock {}
+            Err(_e) => {
+                // if e.kind() == std::io::ErrorKind::WouldBlock {}
                 continue;
             }
         }
@@ -114,7 +114,7 @@ pub async fn send_msg(stream: &mut &TcpStream, packet_as_bytes: Vec<u8>) -> Resu
 /// Set Node to wait for response from Host, with data to be deserialized into `Msg<T>`-type
 // #[tracing::instrument]
 pub async fn await_response<T: Message>(
-    stream: &mut &TcpStream,
+    stream: &TcpStream,
     max_buffer_size: usize,
 ) -> Result<Msg<T>, Error> {
     // Read the requested data into a buffer
@@ -138,8 +138,8 @@ pub async fn await_response<T: Message>(
                     Err(_e) => return Err(Error::Deserialization),
                 }
             }
-            Err(e) => {
-                if e.kind() == std::io::ErrorKind::WouldBlock {}
+            Err(_e) => {
+                // if e.kind() == std::io::ErrorKind::WouldBlock {}
                 debug!("Would block");
                 continue;
             }

--- a/src/node/udp/active.rs
+++ b/src/node/udp/active.rs
@@ -1,8 +1,11 @@
 use crate::node::network_config::Udp;
 use crate::node::Interface;
+use crate::node::Node;
 use crate::Error;
-use crate::*;
+use crate::{Active, Idle, MsgType};
 use std::marker::PhantomData;
+
+use crate::node::udp::*;
 
 use chrono::Utc;
 
@@ -73,5 +76,62 @@ impl<T: Message + 'static> Node<Udp, Active, T> {
                 }
             }
         })
+    }
+
+    #[tracing::instrument]
+    pub fn request(&self) -> Result<Msg<T>, Error> {
+        let mut socket = match self.socket.as_ref() {
+            Some(socket) => socket,
+            None => return Err(Error::AccessSocket),
+        };
+
+        let packet: GenericMsg = GenericMsg {
+            msg_type: MsgType::GET,
+            timestamp: Utc::now(),
+            topic: self.topic.to_string(),
+            data_type: std::any::type_name::<T>().to_string(),
+            data: Vec::new(),
+        };
+
+        let packet_as_bytes: Vec<u8> = match to_allocvec(&packet) {
+            Ok(packet) => packet,
+            Err(_e) => return Err(Error::Serialization),
+        };
+
+        self.runtime.block_on(async {
+            if let Ok(n) = self.send_msg(packet_as_bytes).await {
+                match await_response::<T>(&mut socket, self.cfg.network_cfg.max_buffer_size).await {
+                    Ok(msg) => Ok(msg),
+                    Err(_e) => Err(Error::Deserialization),
+                }
+            } else {
+                Err(Error::BadResponse)
+            }
+        })
+    }
+
+    async fn send_msg(&self, packet_as_bytes: Vec<u8>) -> Result<usize, Error> {
+        match &self.socket {
+            Some(socket) => {
+                match socket.writable().await {
+                    Ok(_) => (),
+                    Err(_e) => return Err(Error::AccessSocket),
+                };
+
+                // Write the request
+                // TO_DO: This should be a loop with a maximum number of attempts
+                for i in 0..10 {
+                    match socket
+                        .send_to(&packet_as_bytes, self.cfg.network_cfg.host_addr)
+                        .await
+                    {
+                        Ok(n) => return Ok(n),
+                        Err(e_) => {}
+                    }
+                }
+                Err(Error::BadResponse)
+            }
+            None => Err(Error::AccessSocket),
+        }
     }
 }

--- a/src/node/udp/active.rs
+++ b/src/node/udp/active.rs
@@ -99,7 +99,7 @@ impl<T: Message + 'static> Node<Udp, Active, T> {
         };
 
         self.runtime.block_on(async {
-            if let Ok(n) = self.send_msg(packet_as_bytes).await {
+            if let Ok(_n) = self.send_msg(packet_as_bytes).await {
                 match await_response::<T>(&mut socket, self.cfg.network_cfg.max_buffer_size).await {
                     Ok(msg) => Ok(msg),
                     Err(_e) => Err(Error::Deserialization),
@@ -119,14 +119,13 @@ impl<T: Message + 'static> Node<Udp, Active, T> {
                 };
 
                 // Write the request
-                // TO_DO: This should be a loop with a maximum number of attempts
-                for i in 0..10 {
+                for _ in 0..10 {
                     match socket
                         .send_to(&packet_as_bytes, self.cfg.network_cfg.host_addr)
                         .await
                     {
                         Ok(n) => return Ok(n),
-                        Err(e_) => {}
+                        Err(_e) => {}
                     }
                 }
                 Err(Error::BadResponse)

--- a/src/node/udp/active.rs
+++ b/src/node/udp/active.rs
@@ -80,7 +80,7 @@ impl<T: Message + 'static> Node<Udp, Active, T> {
 
     #[tracing::instrument]
     pub fn request(&self) -> Result<Msg<T>, Error> {
-        let mut socket = match self.socket.as_ref() {
+        let socket = match self.socket.as_ref() {
             Some(socket) => socket,
             None => return Err(Error::AccessSocket),
         };
@@ -100,7 +100,7 @@ impl<T: Message + 'static> Node<Udp, Active, T> {
 
         self.runtime.block_on(async {
             if let Ok(_n) = self.send_msg(packet_as_bytes).await {
-                match await_response::<T>(&mut socket, self.cfg.network_cfg.max_buffer_size).await {
+                match await_response::<T>(socket, self.cfg.network_cfg.max_buffer_size).await {
                     Ok(msg) => Ok(msg),
                     Err(_e) => Err(Error::Deserialization),
                 }

--- a/src/node/udp/mod.rs
+++ b/src/node/udp/mod.rs
@@ -1,3 +1,72 @@
 mod active;
 mod idle;
 // mod subscription
+
+use crate::msg::{GenericMsg, Message, Msg};
+use std::convert::TryInto;
+use tokio::net::UdpSocket;
+
+use tracing::*;
+
+use crate::Error;
+
+/// Send a `GenericMsg` of `MsgType` from the Node to the Host
+/* pub async fn send_msg(socket: &mut &UdpSocket, packet_as_bytes: Vec<u8>) -> Result<(), Error> {
+    println!("Checking if UDP socket is writeable");
+    match socket.writable().await {
+        Ok(_) => (),
+        Err(_e) => return Err(Error::AccessSocket),
+    };
+    println!("Yes UDP socket is writeable");
+
+    // Write the request
+    // TO_DO: This should be a loop with a maximum number of attempts
+    for _ in 0..self.{
+        println!("Trying to send");
+        match socket.send(&packet_as_bytes) {
+            Ok(_n) => {
+                // debug!("Node successfully wrote {}-byte request to host",n);
+                break;
+            }
+            Err(e) => {
+                if e.kind() == std::io::ErrorKind::WouldBlock {}
+                continue;
+            }
+        }
+    }
+    Ok(())
+} */
+
+pub async fn await_response<T: Message>(
+    socket: &mut &UdpSocket,
+    max_buffer_size: usize,
+) -> Result<Msg<T>, Error> {
+    // Read the requested data into a buffer
+    // TO_DO: Having to re-allocate this each time isn't very efficient
+    let mut buf = vec![0u8; max_buffer_size];
+    // TO_DO: This can be made cleaner
+    loop {
+        socket.readable().await.unwrap();
+        match socket.try_recv(&mut buf) {
+            Ok(0) => continue,
+            Ok(n) => {
+                let bytes = &buf[..n];
+                match postcard::from_bytes::<GenericMsg>(bytes) {
+                    Ok(generic) => {
+                        if let Ok(msg) = TryInto::<Msg<T>>::try_into(generic) {
+                            return Ok(msg);
+                        } else {
+                            return Err(Error::Deserialization);
+                        }
+                    }
+                    Err(_e) => return Err(Error::Deserialization),
+                }
+            }
+            Err(e) => {
+                if e.kind() == std::io::ErrorKind::WouldBlock {}
+                debug!("Would block");
+                continue;
+            }
+        }
+    }
+}

--- a/src/node/udp/mod.rs
+++ b/src/node/udp/mod.rs
@@ -10,35 +10,8 @@ use tracing::*;
 
 use crate::Error;
 
-/// Send a `GenericMsg` of `MsgType` from the Node to the Host
-/* pub async fn send_msg(socket: &mut &UdpSocket, packet_as_bytes: Vec<u8>) -> Result<(), Error> {
-    println!("Checking if UDP socket is writeable");
-    match socket.writable().await {
-        Ok(_) => (),
-        Err(_e) => return Err(Error::AccessSocket),
-    };
-    println!("Yes UDP socket is writeable");
-
-    // Write the request
-    // TO_DO: This should be a loop with a maximum number of attempts
-    for _ in 0..self.{
-        println!("Trying to send");
-        match socket.send(&packet_as_bytes) {
-            Ok(_n) => {
-                // debug!("Node successfully wrote {}-byte request to host",n);
-                break;
-            }
-            Err(e) => {
-                if e.kind() == std::io::ErrorKind::WouldBlock {}
-                continue;
-            }
-        }
-    }
-    Ok(())
-} */
-
 pub async fn await_response<T: Message>(
-    socket: &mut &UdpSocket,
+    socket: &UdpSocket,
     max_buffer_size: usize,
 ) -> Result<Msg<T>, Error> {
     // Read the requested data into a buffer
@@ -62,8 +35,8 @@ pub async fn await_response<T: Message>(
                     Err(_e) => return Err(Error::Deserialization),
                 }
             }
-            Err(e) => {
-                if e.kind() == std::io::ErrorKind::WouldBlock {}
+            Err(_e) => {
+                // if e.kind() == std::io::ErrorKind::WouldBlock {}
                 debug!("Would block");
                 continue;
             }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -59,8 +59,6 @@ fn integrate_host_and_single_node() {
 
         assert_eq!(pose, result.data);
     }
-
-    // host.stop().unwrap();
 }
 
 #[test]
@@ -80,8 +78,6 @@ fn request_non_existent_topic() {
         dbg!(&result);
         thread::sleep(Duration::from_millis(50));
     }
-
-    host.stop().unwrap();
 }
 
 #[test]
@@ -112,8 +108,6 @@ fn node_send_options() {
     let result = node_b.request();
     dbg!(&result);
     assert_eq!(result.unwrap().data, None);
-
-    host.stop().unwrap();
 }
 
 #[test]
@@ -168,8 +162,6 @@ fn subscription_usize() {
         }
         // dbg!(result);
     }
-
-    // host.stop().unwrap();
 }
 
 #[test]
@@ -195,13 +187,7 @@ fn simple_udp() {
     host.start().unwrap();
     println!("Started host");
 
-    let tx = NodeConfig::<Udp, f32>::new("num")
-        .build()
-        .unwrap()
-        .activate()
-        .unwrap();
-
-    let rx = NodeConfig::<Tcp, f32>::new("num")
+    let node = NodeConfig::<Udp, f32>::new("num")
         .build()
         .unwrap()
         .activate()
@@ -210,14 +196,14 @@ fn simple_udp() {
     for i in 0..10 {
         let x = i as f32;
 
-        match tx.publish(x) {
+        match node.publish(x) {
             Ok(_) => (),
             Err(e) => {
                 dbg!(e);
             }
         };
         thread::sleep(Duration::from_millis(1));
-        let result = rx.request().unwrap();
+        let result = node.request().unwrap();
         assert_eq!(x, result.data);
     }
 }

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -26,11 +26,6 @@ fn main() {
         .run()
         .expect("Please check that all documentation follows rustdoc standards");
 
-    // Need this to check for Serde >=1.0.171 due to binary blobs
-    cmd!(sh, "cargo deny check bans")
-        .run()
-        .expect("Please check that all documentation follows rustdoc standards");
-
     // These tests are already run on the CI
     // Using a double-negative here allows end-users to have a nicer experience
     // as we can pass in the extra argument to the CI script


### PR DESCRIPTION
* `Host` uses sled's `Tree` for storing topics now, instead of one tree storing topics on a single key-value. As a result, we should be able to store/retrieve full logs just by setting the logs to not be temporary on the `SledConfig`. See `host_and_single_node` for an example of this. However, that might mean that we need to be careful about publish rates vs. disk size in the future.

* Revert serde back to 1.0 due to upstream fix 

* Add initial `request()` implementation for UDP

* Update test and benchmarks. Benchmarks are actually looking more like <50 us, but keeping it as <100 us in the README in case that's just because I'm on a fast machine. 